### PR TITLE
チェックボックスの切り替えを子コンポーネントではなく親コンポーネントで管理するように

### DIFF
--- a/src/components/SelectPrefectures.tsx
+++ b/src/components/SelectPrefectures.tsx
@@ -1,13 +1,13 @@
 // 都道府県を選択するチェックボックス
 
-import { ChangeEvent } from "react";
 import styled from "styled-components";
 
+import { Prefecture } from "@/libs/ResasApi";
 import { usePrefectures } from "@/libs/ResasApi";
 
 type Props = {
   // 親のuseStateを呼び出す
-  selectedPrefs: number[];
+  selectedPrefs: Prefecture[];
   handleCheckboxChange: Function;
 };
 
@@ -23,15 +23,7 @@ const SelectPrefectures: React.FC<Props> = (prop) => {
         <Wrapper>
           {prefectures() ? (
             prefectures()!.map((prefecture, prefIdx) => (
-              <CheckBoxWrap
-                key={prefIdx}
-                style={{
-                  // 選択中の場合は背景色をつける
-                  background: prop.selectedPrefs.includes(prefecture.prefCode)
-                    ? "#67e8f9"
-                    : "none",
-                }}
-              >
+              <CheckBoxWrap key={prefIdx}>
                 <input
                   type="checkbox"
                   id={"pref" + prefecture.prefCode}

--- a/src/libs/ResasApi.ts
+++ b/src/libs/ResasApi.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import useSWR from "swr";
 
 // 都道府県の型
-type Prefecture = {
+export type Prefecture = {
   prefCode: number;
   prefName: string;
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,20 +1,20 @@
 import type { NextPage } from "next";
-import styles from "@/styles/Home.module.scss";
-
-import SelectPrefectures from "@/components/SelectPrefectures";
 import { useState } from "react";
+
+import { Prefecture } from "@/libs/ResasApi";
+import SelectPrefectures from "@/components/SelectPrefectures";
 
 const Home: NextPage = () => {
   // 選択中の都道府県のPrefCode
-  const [selectedPrefs, setSelectedPrefs] = useState<number[]>([]);
+  const [selectedPrefs, setSelectedPrefs] = useState<Prefecture[]>([]);
 
   // チェックを切り替えたとき
-  function handleCheckboxChange(checked: boolean, prefCode: number) {
+  function handleCheckboxChange(checked: boolean, pref: Prefecture) {
     // 引数のprefCodeと一致するものを削除する
-    const _new = selectedPrefs.filter((pref) => pref != prefCode);
+    const _new = selectedPrefs.filter((sp) => sp != pref);
     // 選択したときは要素を追加
     if (checked) {
-      _new.push(prefCode);
+      _new.push(pref);
     }
     // 親の配列を更新
     setSelectedPrefs(_new);


### PR DESCRIPTION
SelectPrefectureコンポーネントで、チェックボックスの切り替えを管理していたが、グラフ描画のトリガーとするため親コンポーネントで管理し、propsで渡す仕様に変更。
選択中の都道府県をprefCodeで管理していたが、prefNameも含めるように変更。