### PR TITLE
SelectPrefectures.tsxのテストが失敗する問題を修正

### DIFF
--- a/__test__/__snapshots__/SelectPrefectures.test.tsx.snap
+++ b/__test__/__snapshots__/SelectPrefectures.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`コンポーネントを描画 47都道府県のチェックボック�
     >
       <div
         class="sc-gsDKAQ cFnCUf"
-        style="background: none;"
       >
         <input
           id="pref1"
@@ -22,7 +21,6 @@ exports[`コンポーネントを描画 47都道府県のチェックボック�
       </div>
       <div
         class="sc-gsDKAQ cFnCUf"
-        style="background: none;"
       >
         <input
           id="pref2"
@@ -36,7 +34,6 @@ exports[`コンポーネントを描画 47都道府県のチェックボック�
       </div>
       <div
         class="sc-gsDKAQ cFnCUf"
-        style="background: none;"
       >
         <input
           id="pref3"


### PR DESCRIPTION
以前のプルリク時に、`npm run test -- -u`でスナップショットをアップデートしていなかったことが原因。
アップデートを実施し、テストがPASSするようにした。