### PR TITLE
usePrefectures関数でResasApi独自のエラーが検知できていなかった問題を修正

### DIFF
--- a/src/libs/ResasApi.ts
+++ b/src/libs/ResasApi.ts
@@ -36,14 +36,17 @@ export function usePrefectures() {
 
   return {
     // データは整形して返す
-    prefectures: (): Prefecture[] | null => {
+    prefectures: (): Prefecture[] | void => {
       // undefinedの場合は取得中なので早期return
-      if (data == undefined) return null;
-      // messageがnullの場合は取得が成功している
-      if (data["message"] == null) {
-        return data["result"] as Prefecture[];
+      if (data == undefined) return;
+      // Resas独自のエラーをチェック
+      const ResasError = isRESASError(data);
+      if (ResasError) {
+        console.log(`${ResasError.statusCode}: ${ResasError.errorMessage}`);
+        return;
       }
-      return null;
+      // 成功
+      return data["result"] as Prefecture[];
     },
     isLoading: !error && !data,
     isError: error,


### PR DESCRIPTION
- `isRESASError()`を適用
- 他の関数に倣い、エラー時は`null`ではなく`void`を返すように仕様を変更