### PR TITLE
新たに発生したclassName did not match.エラーに対応

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
   "presets": ["next/babel"],
-  "plugins": [["styled-components", { "ssr": true }]]
+  "plugins": [
+    [
+      "styled-components",
+      { "ssr": true, "displayName": true, "preprocess": false }
+    ]
+  ]
 }


### PR DESCRIPTION
[参考](https://github.com/vercel/next.js/issues/7423)