### PR TITLE
RESAS-APIを叩くときにaxios以外のエラーが考慮されていなかった問題を修正

### DIFF
--- a/src/pages/api/population/[prefCode].ts
+++ b/src/pages/api/population/[prefCode].ts
@@ -36,7 +36,7 @@ async function useHandler(req: ExNextApiRequest, res: NextApiResponse) {
       if (axios.isAxiosError(error) && error.response) {
         res.writeHead(Number(error.response.status), error.message);
       } else {
-        console.log(`Error getting population: ${error}`);
+        res.writeHead(500, `${error}`);
       }
     });
 }

--- a/src/pages/api/prefectures.ts
+++ b/src/pages/api/prefectures.ts
@@ -26,7 +26,7 @@ export default async function handler(
       if (axios.isAxiosError(error) && error.response) {
         res.writeHead(Number(error.response.status), error.message);
       } else {
-        console.log(`Error getting prefectures: ${error}`);
+        res.writeHead(500, `${error}`);
       }
     });
 }


### PR DESCRIPTION
#29 への対応
- `/api/prefectures`でAxios以外のエラーがでた場合は500エラーを返すように
- `/api/population/[prefCode]`でAxios以外のエラーがでた場合は500エラーを返すように